### PR TITLE
setup.cfg: update install_requires deprecated to use == instead of ~=

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ package_dir =
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    Deprecated ~= 1.2
+    Deprecated == 1.2.14
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This is necessary to use `pip` with `--require-hashes`.

The motivation for this is: https://github.com/GoogleChromeLabs/chromium-bidi/pull/1283#issuecomment-1714658021

The latest version of `Deprecated` is 1.2.14 as per https://pypi.org/project/Deprecated/.